### PR TITLE
Modified automake/autoconf to deploy config.h as lsfconfig.h

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -9,3 +9,6 @@ SUBDIRS = lsf lsbatch lsf/res eauth scripts chkpnt config examples
 MISSING_FILES = aclocal.m4
 
 MAINTAINERCLEANFILES = $(MISSING_FILES) 
+openlava_libincludedir = $(libdir)/openlava-2.0/include
+nodist_openlava_libinclude_HEADERS = config.h
+

--- a/Makefile.am
+++ b/Makefile.am
@@ -9,6 +9,4 @@ SUBDIRS = lsf lsbatch lsf/res eauth scripts chkpnt config examples
 MISSING_FILES = aclocal.m4
 
 MAINTAINERCLEANFILES = $(MISSING_FILES) 
-openlava_libincludedir = $(libdir)/openlava-2.0/include
-nodist_openlava_libinclude_HEADERS = config.h
-
+include_HEADERS = lsfconfig.h

--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,7 @@
 # Copyright (C) 2011 David Bigagli
 #
 AC_INIT(openlava, 2.0)
-AC_CONFIG_HEADERS(config.h)
+AC_CONFIG_HEADERS(lsfconfig.h)
 AC_PREFIX_DEFAULT([/opt/openlava-2.0])
 
 

--- a/lsf/lsf.h
+++ b/lsf/lsf.h
@@ -20,7 +20,7 @@
 #ifndef _LSF_H_
 #define _LSF_H_
 
-#include <config.h>
+#include <lsfconfig.h>
 #include <stdio.h>
 #include <stdint.h>
 #include <errno.h>

--- a/spec/openlava.spec
+++ b/spec/openlava.spec
@@ -412,6 +412,7 @@ exit 0
 # headers
 %{_includedir}/lsbatch.h
 %{_includedir}/lsf.h
+%{_includedir}/lsfconfig.h
 
 # docs
 %doc COPYING


### PR DESCRIPTION
lsf.h includes config.h which is built but not deployed.   Modified build to use lsfconfig.h rather than config.h and install lsfconfig.h into includedir.
