### PR TITLE
lshosts: fix lshosts <cluster_name> handling

### DIFF
--- a/lsf/lstools/lshosts.c
+++ b/lsf/lstools/lshosts.c
@@ -377,8 +377,12 @@ main(int argc, char **argv)
 	        fprintf(stderr, "lshosts: %s\n", ls_sysmsg());
                 unknown = 1;
                 continue;
-            } else if ((isClus == 0) &&
-                       ((hp = Gethostbyname_(argv[optind])) == NULL)) {
+            } else if (isClus == 1) {
+                /* no multi-cluster support yet */
+                options = ALL_CLUSTERS;
+                i = 0;
+                break;
+            } else if ((hp = Gethostbyname_(argv[optind])) == NULL) {
                 fprintf(stderr, "\
 %s: gethostbyname() failed for host %s.\n", __func__, argv[optind]);
                 unknown = 1;


### PR DESCRIPTION
treats lshosts <cluster_name> as lshosts allclusters
if <cluster_name> is the LSF cluster name