### PR TITLE
Add some missing variable initializations.

### DIFF
--- a/lsbatch/cmd/bjobs.c
+++ b/lsbatch/cmd/bjobs.c
@@ -84,12 +84,12 @@ usage (char *cmd)
 int
 main(int argc, char **argv)
 {
-    char *jobName = 0;
+    char *jobName = NULL;
     int  options;
-    char *user = 0;
-    char *queue = 0;
-    char *host = 0;
-    char *projectName = 0;
+    char *user = NULL;
+    char *queue = NULL;
+    char *host = NULL;
+    char *projectName = NULL;
     int  format = 0;
     struct jobInfoHead *jInfoH;
     struct jobInfoEnt *job;

--- a/lsbatch/cmd/bjobs.c
+++ b/lsbatch/cmd/bjobs.c
@@ -84,12 +84,12 @@ usage (char *cmd)
 int
 main(int argc, char **argv)
 {
-    char *jobName;
+    char *jobName = 0;
     int  options;
-    char *user;
-    char *queue;
-    char *host;
-    char *projectName;
+    char *user = 0;
+    char *queue = 0;
+    char *host = 0;
+    char *projectName = 0;
     int  format = 0;
     struct jobInfoHead *jInfoH;
     struct jobInfoEnt *job;

--- a/lsbatch/cmd/bqueues.c
+++ b/lsbatch/cmd/bqueues.c
@@ -56,14 +56,14 @@ int
 main(int argc, char **argv)
 {
     int numQueues = 0;
-    char **queueNames = 0;
-    char **queues = 0;
-    struct queueInfoEnt *queueInfo = 0;
+    char **queueNames = NULL;
+    char **queues = NULL;
+    struct queueInfoEnt *queueInfo = NULL;
     char lflag = FALSE;
     int cc = 0;
     int defaultQ = 0;
-    char *host = 0;
-    char *user = 0;
+    char *host = NULL;
+    char *user = NULL;
 
     if (lsb_init(argv[0]) < 0) {
         lsb_perror("lsb_init");

--- a/lsbatch/cmd/bqueues.c
+++ b/lsbatch/cmd/bqueues.c
@@ -55,17 +55,15 @@ usage(const char *cmd)
 int
 main(int argc, char **argv)
 {
-    int numQueues;
-    char **queueNames;
-    char **queues;
-    struct queueInfoEnt *queueInfo;
+    int numQueues = 0;
+    char **queueNames = 0;
+    char **queues = 0;
+    struct queueInfoEnt *queueInfo = 0;
     char lflag = FALSE;
-    int cc;
-    int defaultQ;
-    char *host;
-    char *user;
-
-    numQueues = 0;
+    int cc = 0;
+    int defaultQ = 0;
+    char *host = 0;
+    char *user = 0;
 
     if (lsb_init(argv[0]) < 0) {
         lsb_perror("lsb_init");


### PR DESCRIPTION
This fixes the case where running bjobs or bqueue prints invalid strings when run with no options.

Prior to the fix, I get:
$ bqueues
: Bad host name, host group name or cluster name

$ bjobs
No job found in project H\ufffd\ufffdunL\ufffd\ufffdL\ufffd\ufffdD\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffdH\ufffd\ufffduY\ufffdtL\ufffd\ufffdL\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffdH\ufffd\ufffduCD9t$
                                                                          vA\ufffd\ufffd\ufffd\ufffdfD
