### PR TITLE
Fix the use of custom cluster name in `openlavacluster`.

### DIFF
--- a/config/Makefile.am
+++ b/config/Makefile.am
@@ -12,7 +12,7 @@ include $(top_srcdir)/common.mk
 # script in the etc directory.
 etcdir = $(prefix)/etc
 noinst_DATA = openlava.sh openlava.csh \
-	lsf.conf lsf.cluster.openlava lsf.shared lsf.task \
+	lsf.conf lsf.cluster.${openlavacluster} lsf.shared lsf.task \
 	lsb.hosts lsb.params lsb.queues lsb.users 
 
 etc_SCRIPTS = openlava


### PR DESCRIPTION
The configure script allows us to use a custom name of the cluster instead of `openlava`. There is change in [Makefile.am](Makefile.am) in root directory. However, in [config/Makefile.am](config/Makefile.am), the default cluster name `openlava` is still used. Consequently, one receives the following error while compiling with `make`.

```
$ mkdir build && cd build
$ ../configure --prefix=/opt/local/openlava/2.2.1 openlavaadmin=lava openlavacluster=foo
$ make
...
Making all in config
make[2]: Entering directory '/tmp/openlava/build/config'
make[2]: *** No rule to make target 'lsf.cluster.openlava', needed by 'all-am'.  Stop.
...
```

This fix will replace the default `openlava` with the one set via `openlavacluster`.